### PR TITLE
Ease Developers' Getting Started experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 # Smaug
 A map editor designed for rapid iteration
 
-[Discord Server](https://discord.gg/ePnUDsKtWZ)
+[Discord Server]
 
+[Discord Server]: https://discord.gg/ePnUDsKtWZ
+
+## Installation
+Join the [Discord Server], and download the latest archive from the #announcements channel.
+
+## Getting Started
+(for Smaug Development)
+
+1. Run CMake to generate project files in a `build` folder.
+
+2. Clone the `SmaugAssets` using [Git LFS].
+Please check that the assets are properly cloned by opening an image in your photo viewer.
+
+[Git LFS]: https://www.atlassian.com/git/tutorials/git-lfs
+
+3. Copy the contents of `SmaugAssets` into your `build` folder.
+
+Smaug can now be run from the build directory
+
+## License
 All files under ./Smaug/mesh are licensed under LGPL-2.1
 
 ```

--- a/Smaug/CMakeLists.txt
+++ b/Smaug/CMakeLists.txt
@@ -103,6 +103,9 @@ include_directories( . )
 add_executable( smaug ${SOURCES} ${VERTEX_SHADERS} ${FRAGMENT_SHADERS} shaders/varying.def.sc )
 target_include_directories( smaug PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} assimp mesh )
 target_link_libraries( smaug bigg keyvalues assimp )
+set_target_properties( smaug PROPERTIES
+	VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+)
 
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT smaug)
 

--- a/Smaug/CMakeLists.txt
+++ b/Smaug/CMakeLists.txt
@@ -104,5 +104,8 @@ add_executable( smaug ${SOURCES} ${VERTEX_SHADERS} ${FRAGMENT_SHADERS} shaders/v
 target_include_directories( smaug PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} assimp mesh )
 target_link_libraries( smaug bigg keyvalues assimp )
 
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT smaug)
 
 install(DIRECTORY ${SHADER_OUT_DIR} DESTINATION bin)
+
+

--- a/Smaug/texturemanager.cpp
+++ b/Smaug/texturemanager.cpp
@@ -43,51 +43,76 @@ bgfx::TextureHandle CTextureManager::LoadTexture(const char* path)
 
 	// Comp is how many components each pixel is made up of
 	int width, height, comp;
+	stbi_uc* image;
 
-	stbi_uc* image = stbi_load(path, &width, &height, &comp, 0);
-		
-	// Did we actually get the image?
-	if (image)
+	// An unrolled version of stbi_load
+	// lets us do better error reporting
 	{
-		size_t size = (size_t)width * height * comp * sizeof(stbi_uc);
-
-		// If we use a reference here, we'd have to maintain the pixel data ourselves. This just makes it easier
-		const bgfx::Memory* mem = bgfx::alloc(size);
-		memcpy(mem->data, image, size);
-		delete[] image;
-
-		// Figure out what kinda foramt this uses
-		bgfx::TextureFormat::Enum format = bgfx::TextureFormat::Enum::Unknown;
-		switch (comp)
+		FILE* f = stbi__fopen(path, "rb");
+		if (!f)
 		{
-		case 1:
-			format = bgfx::TextureFormat::Enum::R8; // Wrong. Should be Gray
-			break;
-		case 2:
-			format = bgfx::TextureFormat::Enum::RG8; // Wrong. Should be Gray Alpha
-			break;
-		case 3:
-			format = bgfx::TextureFormat::Enum::RGB8;
-			break;
-		case 4:
-			format = bgfx::TextureFormat::Enum::RGBA8;
-			break;
+			printf("[Texture Manager] Failed to load image %s: File not found\n", path);
+			return ErrorTexture();
 		}
 
+		// LFS check
+		char contents[8];
+		fgets(contents, sizeof(contents), f);
+		// An LFS meta file starts with "version"
+		// if (strcmp(contents, "version") == 0)
+		if (*(uint64_t*)contents == *(uint64_t*)"version")
+		{
+			printf("[Texture Manager] Failed to load image %s: LFS detected\n", path);
+			printf("[Texture Manager] See the Getting Started section of the README for more info\n");
+			return ErrorTexture();
+		}
 
-		bgfx::TextureHandle textureHandle = bgfx::createTexture2D(width, height, false, 1, format, 0, mem);
-
-		// Put this in our map so we can grab it later instead of loading it again.
-		m_textureMap.insert({ path, textureHandle });
-
-
-		printf("[Texture Manager] Loaded image %s\n", path);
-		return textureHandle;
+		rewind(f);
+		image = stbi_load_from_file(f, &width, &height, &comp, 0);
+		fclose(f);
 	}
 
-	// Oh, no. We failed to load the image...
-	printf("[Texture Manager] Failed to load image %s\n", path);
-	return ErrorTexture();
+	if (!image)
+	{
+		// Oh, no. We failed to load the image...
+		printf("[Texture Manager] Failed to load image %s: Corrupt image\n", path);
+		return ErrorTexture();
+	}
+
+	size_t size = (size_t)width * height * comp * sizeof(stbi_uc);
+
+	// If we use a reference here, we'd have to maintain the pixel data ourselves. This just makes it easier
+	const bgfx::Memory* mem = bgfx::alloc(size);
+	memcpy(mem->data, image, size);
+	delete[] image;
+
+	// Figure out what kinda foramt this uses
+	bgfx::TextureFormat::Enum format = bgfx::TextureFormat::Enum::Unknown;
+	switch (comp)
+	{
+	case 1:
+		format = bgfx::TextureFormat::Enum::R8; // Wrong. Should be Gray
+		break;
+	case 2:
+		format = bgfx::TextureFormat::Enum::RG8; // Wrong. Should be Gray Alpha
+		break;
+	case 3:
+		format = bgfx::TextureFormat::Enum::RGB8;
+		break;
+	case 4:
+		format = bgfx::TextureFormat::Enum::RGBA8;
+		break;
+	}
+
+
+	bgfx::TextureHandle textureHandle = bgfx::createTexture2D(width, height, false, 1, format, 0, mem);
+
+	// Put this in our map so we can grab it later instead of loading it again.
+	m_textureMap.insert({ path, textureHandle });
+
+
+	printf("[Texture Manager] Loaded image %s\n", path);
+	return textureHandle;
 }
 
 bgfx::TextureHandle CTextureManager::ErrorTexture()

--- a/Smaug/utils.cpp
+++ b/Smaug/utils.cpp
@@ -127,7 +127,7 @@ glm::vec2 SolveToLine2D(glm::vec2 pos, glm::vec2 lineStart, glm::vec2 lineEnd, S
 bgfx::ProgramHandle LoadShader(const char* fragment, const char* vertex)
 {
 	// Static so we don't reinitiate this
-	static const char** shaderPaths = new const char* [10]
+	static char const *const shaderPaths[bgfx::RendererType::Count] =
 	{
 		nullptr,		  // No Renderer
 		"shaders/dx9/",   // Direct3D9
@@ -135,10 +135,11 @@ bgfx::ProgramHandle LoadShader(const char* fragment, const char* vertex)
 		"shaders/dx11/",  // Direct3D12
 		nullptr,		  // Gnm
 		nullptr,		  // Metal
-		nullptr,		  // Nvm
+		nullptr,		  // Nvn
 		"shaders/glsl/",  // OpenGL
 		nullptr,		  // OpenGL ES
 		"shaders/spirv/", // Vulkan
+		nullptr,		  // WebGPU
 	};
 
 	int type = bgfx::getRendererType();

--- a/Smaug/utils.cpp
+++ b/Smaug/utils.cpp
@@ -1,5 +1,6 @@
 #include "utils.h"
 #include <bigg.hpp>
+#include <filesystem>
 
 bool IsPointOnLine2D(glm::vec3 point1, glm::vec3 point2, glm::vec3 mouse, float range)
 {
@@ -124,7 +125,7 @@ glm::vec2 SolveToLine2D(glm::vec2 pos, glm::vec2 lineStart, glm::vec2 lineEnd, S
 	}
 }
 
-bgfx::ProgramHandle LoadShader(const char* fragment, const char* vertex)
+bgfx::ProgramHandle LoadShader(const char* fragment, const char* vertex, bgfx::ProgramHandle fallback)
 {
 	// Static so we don't reinitiate this
 	static char const *const shaderPaths[bgfx::RendererType::Count] =
@@ -158,13 +159,26 @@ bgfx::ProgramHandle LoadShader(const char* fragment, const char* vertex)
 		return BGFX_INVALID_HANDLE;
 	}
 
-	char vsPath[128];
-	strcpy(vsPath, shaderPath);
-	strcat(vsPath, vertex);
+	char vsPath[128] = "";
+	strncat(vsPath, shaderPath, sizeof(vsPath));
+	strncat(vsPath, vertex, sizeof(vsPath));
 
-	char fsPath[128];
-	strcpy(fsPath, shaderPath);
-	strcat(fsPath, fragment);
+	if (!std::filesystem::exists(vsPath))
+	{
+		printf("[Utils::LoadShader] Vertex shader %s not found\n", vsPath);
+		return fallback;
+	}
+
+	char fsPath[128] = "";
+	strncat(fsPath, shaderPath, sizeof(fsPath));
+	strncat(fsPath, fragment, sizeof(fsPath));
+
+	if (!std::filesystem::exists(fsPath))
+	{
+		printf("[Utils::LoadShader] Fragment shader %s not found\n", fsPath);
+		return fallback;
+	}
+
 
 	return bigg::loadProgram(vsPath, fsPath);
 }

--- a/Smaug/utils.h
+++ b/Smaug/utils.h
@@ -21,7 +21,7 @@ enum class SolveToLine2DSnap
 };
 glm::vec2 SolveToLine2D(glm::vec2 pos, glm::vec2 lineStart, glm::vec2 lineEnd, SolveToLine2DSnap* snap = nullptr);
 
-bgfx::ProgramHandle LoadShader(const char* fragment, const char* vertex);
+bgfx::ProgramHandle LoadShader(const char* fragment, const char* vertex, bgfx::ProgramHandle fallback = BGFX_INVALID_HANDLE );
 
 // Pitch, Yaw, Roll
 void Directions(glm::vec3 angles, glm::vec3* forward = nullptr, glm::vec3* right = nullptr, glm::vec3* up = nullptr);


### PR DESCRIPTION
Mostly quality of life improvements, but also has two safety improvements:
1. shaderpaths table now fails to compile if the bgfx RendererType::Count doesn't match the table size
2. utils' LoadShader now truncates filenames rather than corrupting memory.