### PR TITLE
Fixes for support macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,17 @@
-cmake_minimum_required( VERSION 3.1 )
+cmake_minimum_required( VERSION 3.9 )
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_HOME_DIRECTORY}/build )
+
+
 set(ASSIMP_NO_EXPORT ON CACHE BOOL "" FORCE)
 set(ASSIMP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(ASSIMP_BUILD_ASSIMP_TOOLS OFF CACHE BOOL "" FORCE)
+set(ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT OFF CACHE BOOL "" FORCE)
+set(ASSIMP_BUILD_OBJ_IMPORTER ON CACHE BOOL "" FORCE)
 
 project( smaug )
 
@@ -24,3 +31,15 @@ add_subdirectory( smesh )
 add_subdirectory( sworld )
 add_subdirectory( Smaug )
 add_subdirectory( front )
+
+set(CMAKE_XCODE_GENERATE_SCHEME OFF)
+set_target_properties(front PROPERTIES XCODE_GENERATE_SCHEME ON)
+
+if ( APPLE )
+    target_compile_definitions(bgfx PUBLIC BGFX_CONFIG_MULTITHREADED=0)
+endif()
+
+
+if ( CMAKE_CXX_COMPILER_ID MATCHES ".*Clang" )
+    set_target_properties(assimp PROPERTIES COMPILE_FLAGS "-Wno-shorten-64-to-32 -Wno-deprecated -Wno-unused -Wno-ordered-compare-function-pointers")
+endif()

--- a/Smaug/utils.h
+++ b/Smaug/utils.h
@@ -31,7 +31,7 @@ glm::vec2 SolveToLine2D(glm::vec2 pos, glm::vec2 lineStart, glm::vec2 lineEnd, S
 #define COLOR_WHITE glm::vec3( 1.0, 1.0, 1.0 )
 #define COLOR_GRAY  glm::vec3( 0.5, 0.5, 0.5 )
 
-inline constexpr glm::vec3 colorHSV(float hue, float saturation, float value)
+inline glm::vec3 colorHSV(float hue, float saturation, float value)
 {
 	const float hueRange = 2 * PI;
 	const float onesixth = hueRange / 6;
@@ -43,7 +43,8 @@ inline constexpr glm::vec3 colorHSV(float hue, float saturation, float value)
 	oB = (oB * saturation + (1.0f - saturation)) * value;
 	return glm::vec3(oR, oG, oB);
 }
-inline constexpr glm::vec3 colorHSV(glm::vec3 vec) { return colorHSV(vec.x, vec.y, vec.z); }
+
+inline glm::vec3 colorHSV(glm::vec3 vec) { return colorHSV(vec.x, vec.y, vec.z); }
 
 inline glm::vec3 randColorHue()
 {

--- a/front/CMakeLists.txt
+++ b/front/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-set(ASSIMP_NO_EXPORT ON)
-
 set( SOURCES 
 
 	main.cpp
@@ -26,7 +24,9 @@ set( SHADER_OUT_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/shaders" )
 set( GLSL_VERSION 430 )
 set( DX_MODEL 5_0 )
 
-if(UNIX)
+if(APPLE)
+    set( SHADER_PLATFORMS metal )
+elseif(UNIX)
     set( SHADER_PLATFORMS glsl spirv )
 else()
     set( SHADER_PLATFORMS glsl dx11 spirv )

--- a/front/interfaceimpl.cpp
+++ b/front/interfaceimpl.cpp
@@ -84,7 +84,8 @@ renderTarget_t CEngineInterface::CreateRenderTarget(uint32_t width, uint32_t hei
 
 void CEngineInterface::ClearColor(renderTarget_t rt, uint32_t color)
 {
-	bgfx::setViewClear(reinterpret_cast<uint16_t>(rt), BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, color);
+	uint16_t id = reinterpret_cast<uintptr_t>(rt);
+	bgfx::setViewClear(id, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH, color);
 }
 
 void CEngineInterface::DrawGrid(CTransform& transform, int scale)
@@ -94,7 +95,7 @@ void CEngineInterface::DrawGrid(CTransform& transform, int scale)
 
 void CEngineInterface::BeginView(renderTarget_t rt)
 {
-	uint16_t id = reinterpret_cast<uint16_t>(rt);
+	uint16_t id = reinterpret_cast<uintptr_t>(rt);
 	
 	auto& view = m_renderTargets[id-1];
 	ModelManager().SetView(id);
@@ -129,7 +130,8 @@ void CEngineInterface::DrawWorld2D()
 
 texture_t CEngineInterface::TextureFromRenderTarget(renderTarget_t rt)
 {
-	return reinterpret_cast<texture_t>(bgfx::getTexture(m_renderTargets[reinterpret_cast<uint16_t>(rt)-1].framebuffer).idx);
+    uint16_t id = reinterpret_cast<uintptr_t>(rt);
+	return reinterpret_cast<texture_t>(bgfx::getTexture(m_renderTargets[id-1].framebuffer).idx);
 }
 
 bool CEngineInterface::ShouldFlipViews()

--- a/front/main.cpp
+++ b/front/main.cpp
@@ -3,9 +3,11 @@
 
 #ifdef _WIN32
 static constexpr auto DEFAULT_RENDER_TYPE = bgfx::RendererType::Direct3D11;
+#elif __APPLE__
+static constexpr auto DEFAULT_RENDER_TYPE = bgfx::RendererType::Metal;
 #else
 static constexpr auto DEFAULT_RENDER_TYPE = bgfx::RendererType::OpenGL;
-#endif 
+#endif
 
 int main( int argc, char** argv )
 {
@@ -20,6 +22,8 @@ int main( int argc, char** argv )
 		renderType = bgfx::RendererType::Direct3D9;
 	else if(CommandLine::HasAny("-dx11", "-d3d11", "-directx11"))
 		renderType = bgfx::RendererType::Direct3D11;
+	else if(CommandLine::HasAny("-metal"))
+		renderType = bgfx::RendererType::Metal;
 	SetRendererType(renderType);
 	
 	return GetApp().run( argc, argv, renderType );

--- a/front/shadermanager.cpp
+++ b/front/shadermanager.cpp
@@ -36,7 +36,7 @@ bgfx::ProgramHandle LoadShader(const char* fragment, const char* vertex, bgfx::P
 		"shaders/dx11/",  // Direct3D11
 		"shaders/dx11/",  // Direct3D12
 		nullptr,		  // Gnm
-		nullptr,		  // Metal
+		"shaders/metal/", // Metal
 		nullptr,		  // Nvm
 		"shaders/essl/",  // OpenGL ES
 		"shaders/glsl/",  // OpenGL
@@ -135,9 +135,15 @@ void CShaderManager::SetColor(glm::vec4 color)
 void CShaderManager::SetTexture(texture_t texture)
 {
 	if (texture != reinterpret_cast<texture_t>(0))// bgfx::kInvalidHandle))
-		bgfx::setTexture(0, m_textureUniform, { reinterpret_cast<uint16_t>(texture) });
+	{
+		uint16_t id = reinterpret_cast<uintptr_t>(texture);
+		bgfx::setTexture(0, m_textureUniform, { id });
+	}
 	else
-		bgfx::setTexture(0, m_textureUniform, { reinterpret_cast<uint16_t>(TextureManager().ErrorTexture()) });
+	{
+		uint16_t id = reinterpret_cast<uintptr_t>(TextureManager().ErrorTexture());
+		bgfx::setTexture(0, m_textureUniform, { id });
+	}
 }
 
 bgfx::ProgramHandle CShaderManager::GetShaderProgram(Shader shader)

--- a/front/smaugapp.cpp
+++ b/front/smaugapp.cpp
@@ -136,6 +136,7 @@ void SetRendererType(bgfx::RendererType::Enum type)
 		case RT::Direct3D12:
 		case RT::Direct3D9:
 		case RT::Vulkan:
+		case RT::Metal:
 			gRenderProps.coordSystem = ECoordSystem::LEFT_HANDED;
 			break;
 		default:

--- a/smesh/mesh.h
+++ b/smesh/mesh.h
@@ -3,6 +3,7 @@
 #include <glm/vec3.hpp>
 #include <glm/vec2.hpp>
 #include <vector>
+#include <float.h>
 
 /*
 

--- a/sshared/log.h
+++ b/sshared/log.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdio.h>
 #include <stdarg.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <vector>
 #include <typeinfo>
 #include <cstring>

--- a/sshared/shared.h
+++ b/sshared/shared.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <glm/vec3.hpp>
+#include <math.h>
 
 // Dummy stuff so when we rewire this to be bgfx independent, it's easier
 typedef void* texture_t;


### PR DESCRIPTION
Switched off multithreading in BGFX for apple builds to prevent crashes.
CMakeLists was extended to generate xcode projects better.
Assimp build was limited only to OBJ-format.
Fixes to satisfy AppleClang.
Support for Metal.